### PR TITLE
통합 바코드 발급서비스 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.apache.commons:commons-lang3:3.12.0'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/example/membership/service/infra/entity/Membership.java
+++ b/src/main/java/com/example/membership/service/infra/entity/Membership.java
@@ -2,10 +2,12 @@ package com.example.membership.service.infra.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Builder
 @Entity
 public class Membership {
     @Id

--- a/src/main/java/com/example/membership/service/infra/entity/User.java
+++ b/src/main/java/com/example/membership/service/infra/entity/User.java
@@ -13,5 +13,5 @@ import lombok.Getter;
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private final Long id;
+    private Long id;
 }

--- a/src/main/java/com/example/membership/service/infra/entity/UserNotFoundException.java
+++ b/src/main/java/com/example/membership/service/infra/entity/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.membership.service.infra.entity;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(Long userId) {
+        super("user is not found [id" + userId + "]");
+    }
+}

--- a/src/main/java/com/example/membership/service/service/BarcodeCreateService.java
+++ b/src/main/java/com/example/membership/service/service/BarcodeCreateService.java
@@ -1,21 +1,14 @@
 package com.example.membership.service.service;
 
-import com.example.membership.service.infra.entity.*;
+import com.example.membership.service.infra.entity.Membership;
+import com.example.membership.service.infra.entity.MembershipRepository;
+import com.example.membership.service.infra.entity.User;
+import com.example.membership.service.infra.entity.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.stereotype.Service;
 
-import java.util.Random;
-import java.util.UUID;
-
-/*
-요청 값에는 사용자 ID가 포함됩니다.
-사용자 ID는 9자리 숫자, 멤버십 바코드는 10자리 숫자 문자열입니다.
-발급된 멤버십 바코드는 타인과 중복 발급이 불가합니다.
-다음에 발급되는 멤버십 바코드는 예측할 수 없어야 합니다.
-이미 발급된 아이디의 발급 요청 시 기존 멤버십 바코드를 반환합니다.
- */
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -25,9 +18,9 @@ public class BarcodeCreateService {
     private final MembershipRepository membershipRepository;
 
     public void createBarcode(Long userId) {
-        final User user = userRepository.findById(userId).orElseThrow(() ->
-            new UserNotFoundException(userId)
-        );
+        final User user = userRepository.findById(userId).orElseThrow(() -> {
+            throw new RuntimeException("id없음");
+        });
 
         String uuid = RandomStringUtils.randomNumeric(10);
         Membership barcode = Membership.builder().id(uuid).user(user).build();

--- a/src/main/java/com/example/membership/service/service/BarcodeCreateService.java
+++ b/src/main/java/com/example/membership/service/service/BarcodeCreateService.java
@@ -1,0 +1,42 @@
+package com.example.membership.service.service;
+
+import com.example.membership.service.infra.entity.Membership;
+import com.example.membership.service.infra.entity.MembershipRepository;
+import com.example.membership.service.infra.entity.User;
+import com.example.membership.service.infra.entity.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+import java.util.UUID;
+
+/*
+요청 값에는 사용자 ID가 포함됩니다.
+사용자 ID는 9자리 숫자, 멤버십 바코드는 10자리 숫자 문자열입니다.
+발급된 멤버십 바코드는 타인과 중복 발급이 불가합니다.
+다음에 발급되는 멤버십 바코드는 예측할 수 없어야 합니다.
+이미 발급된 아이디의 발급 요청 시 기존 멤버십 바코드를 반환합니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BarcodeCreateService {
+
+    private final UserRepository userRepository;
+    private final MembershipRepository membershipRepository;
+
+    public void createBarcode(Long userId) {
+        final User user = userRepository.findById(userId).orElseThrow(() -> {
+            throw new RuntimeException("id없음");
+        });
+
+        String uuid = RandomStringUtils.randomNumeric(10);
+        Membership barcode = Membership.builder().id(uuid).user(user).build();
+
+        membershipRepository.save(barcode);
+    }
+}
+
+

--- a/src/main/java/com/example/membership/service/service/BarcodeCreateService.java
+++ b/src/main/java/com/example/membership/service/service/BarcodeCreateService.java
@@ -1,9 +1,6 @@
 package com.example.membership.service.service;
 
-import com.example.membership.service.infra.entity.Membership;
-import com.example.membership.service.infra.entity.MembershipRepository;
-import com.example.membership.service.infra.entity.User;
-import com.example.membership.service.infra.entity.UserRepository;
+import com.example.membership.service.infra.entity.*;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -28,9 +25,9 @@ public class BarcodeCreateService {
     private final MembershipRepository membershipRepository;
 
     public void createBarcode(Long userId) {
-        final User user = userRepository.findById(userId).orElseThrow(() -> {
-            throw new RuntimeException("id없음");
-        });
+        final User user = userRepository.findById(userId).orElseThrow(() ->
+            new UserNotFoundException(userId)
+        );
 
         String uuid = RandomStringUtils.randomNumeric(10);
         Membership barcode = Membership.builder().id(uuid).user(user).build();

--- a/src/test/java/com/example/membership/service/service/BarcodeCreateServiceTest.java
+++ b/src/test/java/com/example/membership/service/service/BarcodeCreateServiceTest.java
@@ -1,0 +1,89 @@
+package com.example.membership.service.service;
+
+import com.example.membership.service.infra.entity.Membership;
+import com.example.membership.service.infra.entity.MembershipRepository;
+import com.example.membership.service.infra.entity.User;
+import com.example.membership.service.infra.entity.UserRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@Transactional
+class BarcodeCreateServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private MembershipRepository membershipRepository;
+    @InjectMocks
+    private BarcodeCreateService barcodeCreateService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    private final Long userId = 123456789L;
+
+    @Test
+    void 바코드_발급_성공() {
+        // userRepository.findById() 메소드가 Optional.empty()를 반환하도록 설정
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // barcodeCreate() 메소드를 호출하면 RuntimeException이 발생하는지 검증
+        assertThrows(RuntimeException.class, () -> barcodeCreateService.createBarcode(userId));
+
+        // userRepository.findById() 메소드가 1번 호출되었는지 검증
+        verify(userRepository, times(1)).findById(userId);
+
+        // membershipRepository.save() 메소드가 호출되지 않았는지 검증
+        verify(membershipRepository, never()).save(any(Membership.class));
+
+
+    }
+
+    @Test
+    void membership_Id_10자리_숫자_확인() {
+        // 가상의 유저 객체 생성
+        User user = new User(userId);
+
+        // userRepository.findById() 메소드가 가상의 유저 객체를 반환하도록 설정
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        // barcodeCreate() 메소드 호출
+        barcodeCreateService.createBarcode(userId);
+
+        // membershipRepository.save() 메소드에 전달된 Membership 객체 캡처
+        ArgumentCaptor<Membership> captor = ArgumentCaptor.forClass(Membership.class);
+        verify(membershipRepository).save(captor.capture());
+
+        // 저장된 Membership 객체 가져오기
+        Membership savedMembership = captor.getValue();
+
+        // id 값이 10자리 숫자인지 확인
+        assertTrue(savedMembership.getId().matches("\\d{10}"));
+    }
+
+    @Test
+    void user_id_없는_경우() {
+        // userRepository.findById() 메소드가 가상의 유저 객체를 반환하도록 설정
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // RuntimeException 이 동작하는지 확인
+        RuntimeException runtimeException = assertThrows(RuntimeException.class, () -> barcodeCreateService.createBarcode(userId));
+
+        // id없음이라고 나오는지 확인
+        assertEquals(runtimeException.getMessage(),"id없음");
+    }
+}

--- a/src/test/java/com/example/membership/service/service/BarcodeCreateServiceTest.java
+++ b/src/test/java/com/example/membership/service/service/BarcodeCreateServiceTest.java
@@ -1,9 +1,6 @@
 package com.example.membership.service.service;
 
-import com.example.membership.service.infra.entity.Membership;
-import com.example.membership.service.infra.entity.MembershipRepository;
-import com.example.membership.service.infra.entity.User;
-import com.example.membership.service.infra.entity.UserRepository;
+import com.example.membership.service.infra.entity.*;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,7 +68,6 @@ class BarcodeCreateServiceTest {
         // 저장된 Membership 객체 가져오기
         Membership savedMembership = captor.getValue();
 
-        // id 값이 10자리 숫자인지 확인
         assertTrue(savedMembership.getId().matches("\\d{10}"));
     }
 
@@ -80,10 +76,7 @@ class BarcodeCreateServiceTest {
         // userRepository.findById() 메소드가 가상의 유저 객체를 반환하도록 설정
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
-        // RuntimeException 이 동작하는지 확인
-        RuntimeException runtimeException = assertThrows(RuntimeException.class, () -> barcodeCreateService.createBarcode(userId));
-
-        // id없음이라고 나오는지 확인
-        assertEquals(runtimeException.getMessage(),"id없음");
+        // UserNotFoundException 이 동작하는지 확인
+        assertThrows(UserNotFoundException.class, () -> barcodeCreateService.createBarcode(userId));
     }
 }

--- a/src/test/java/com/example/membership/service/service/BarcodeCreateServiceTest.java
+++ b/src/test/java/com/example/membership/service/service/BarcodeCreateServiceTest.java
@@ -2,7 +2,6 @@ package com.example.membership.service.service;
 
 import com.example.membership.service.infra.entity.*;
 import jakarta.transaction.Transactional;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -12,7 +11,8 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -38,8 +38,8 @@ class BarcodeCreateServiceTest {
         // userRepository.findById() 메소드가 Optional.empty()를 반환하도록 설정
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
-        // barcodeCreate() 메소드를 호출하면 RuntimeException이 발생하는지 검증
-        assertThrows(RuntimeException.class, () -> barcodeCreateService.createBarcode(userId));
+        // barcodeCreate() 메소드를 호출하면 UserNotFoundException 발생하는지 검증
+        assertThrows(UserNotFoundException.class, () -> barcodeCreateService.createBarcode(userId));
 
         // userRepository.findById() 메소드가 1번 호출되었는지 검증
         verify(userRepository, times(1)).findById(userId);


### PR DESCRIPTION
# ISSUE

https://github.com/a01575dc-b401-4506-8753-7d523b558dfa/membership-service/issues/15

# Changes

- [x] gradle dependency : apache 3.12.0 추가
- [x]  회원 ID(9자리 숫자) 당 멤버십 ID(= 바코드 ID)가 10자리의 숫자 문자열로 발급됩니다.
- [ ] 이미 발급된 아이디의 발급 요청 시 기존 멤버십 바코드를 반환합니다.
- [x] 다음에 발급되는 멤버십 바코드는 예측할 수 없어야 합니다.
- [x] 단위테스트 작성