### PR TITLE
#15 Create a Barcode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
+	implementation 'org.apache.commons:commons-lang3:3.12.0'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/example/membership/service/infra/entity/BarcodeSaveAndGetException.java
+++ b/src/main/java/com/example/membership/service/infra/entity/BarcodeSaveAndGetException.java
@@ -1,0 +1,7 @@
+package com.example.membership.service.infra.entity;
+
+public class BarcodeSaveAndGetException extends RuntimeException {
+    public BarcodeSaveAndGetException(Long userId) {
+        super("problem generating barcode [id "+ userId + "]");
+    }
+}

--- a/src/main/java/com/example/membership/service/infra/entity/BarcodeSaveAndGetException.java
+++ b/src/main/java/com/example/membership/service/infra/entity/BarcodeSaveAndGetException.java
@@ -2,6 +2,6 @@ package com.example.membership.service.infra.entity;
 
 public class BarcodeSaveAndGetException extends RuntimeException {
     public BarcodeSaveAndGetException(Long userId) {
-        super("problem generating barcode [id "+ userId + "]");
+        super("Duplicate barcode generation requested [id "+ userId + "]");
     }
 }

--- a/src/main/java/com/example/membership/service/infra/entity/Membership.java
+++ b/src/main/java/com/example/membership/service/infra/entity/Membership.java
@@ -2,13 +2,16 @@ package com.example.membership.service.infra.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Builder
 @Entity
 public class Membership {
     @Id
+    @Column(unique = true)
     private final String id;
     @OneToOne(optional=false,fetch= FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/example/membership/service/infra/entity/Membership.java
+++ b/src/main/java/com/example/membership/service/infra/entity/Membership.java
@@ -11,7 +11,6 @@ import lombok.Getter;
 @Entity
 public class Membership {
     @Id
-    @Column(unique = true)
     private final String id;
     @OneToOne(optional=false,fetch= FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/example/membership/service/infra/entity/MembershipRepository.java
+++ b/src/main/java/com/example/membership/service/infra/entity/MembershipRepository.java
@@ -2,5 +2,8 @@ package com.example.membership.service.infra.entity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MembershipRepository  extends JpaRepository<Membership, String> {
+    Optional<Membership> findByUserId(Long userId);
 }

--- a/src/main/java/com/example/membership/service/infra/entity/UserIdLengthException.java
+++ b/src/main/java/com/example/membership/service/infra/entity/UserIdLengthException.java
@@ -1,0 +1,7 @@
+package com.example.membership.service.infra.entity;
+
+public class UserIdLengthException extends RuntimeException{
+    public UserIdLengthException(Long userId){
+        super("length of user ID is not correct [id " + userId + "]");
+    }
+}

--- a/src/main/java/com/example/membership/service/infra/entity/UserNotFoundException.java
+++ b/src/main/java/com/example/membership/service/infra/entity/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.membership.service.infra.entity;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(Long userId) {
+        super("user is not found [id" + userId + "]");
+    }
+}

--- a/src/main/java/com/example/membership/service/service/BarcodeCreateService.java
+++ b/src/main/java/com/example/membership/service/service/BarcodeCreateService.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class BarcodeCreateService {
 
     private final UserRepository userRepository;

--- a/src/main/java/com/example/membership/service/service/BarcodeCreateService.java
+++ b/src/main/java/com/example/membership/service/service/BarcodeCreateService.java
@@ -16,9 +16,7 @@ public class BarcodeCreateService {
     private final MembershipRepository membershipRepository;
 
     public Membership createBarcode(Long userId) {
-        if(!userId.toString().matches("\\d{9}")){
-            throw new UserIdLengthException(userId);
-        }
+        validateUserId(userId);
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(userId));
         try {
@@ -38,5 +36,17 @@ public class BarcodeCreateService {
                         .user(user)
                         .build()
         );
+    }
+
+    private void validateUserId(Long userId){
+        if(userId == null) {
+            throw new IllegalArgumentException("user Id is NULL");
+        }
+        if(userId <= 0) {
+            throw new IllegalArgumentException("user ID is negative");
+        }
+        if(String.valueOf(userId).length() != 9) {
+            throw new UserIdLengthException(userId);
+        }
     }
 }

--- a/src/main/java/com/example/membership/service/service/BarcodeCreateService.java
+++ b/src/main/java/com/example/membership/service/service/BarcodeCreateService.java
@@ -16,11 +16,11 @@ public class BarcodeCreateService {
     private final MembershipRepository membershipRepository;
 
     public Membership createBarcode(Long userId) {
-        final User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserNotFoundException(userId));
-        if(!user.getId().toString().matches("\\d{9}")){
+        if(!userId.toString().matches("\\d{9}")){
             throw new UserIdLengthException(userId);
         }
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
         try {
             return membershipRepository.findByUserId(user.getId())
                     .orElseGet(() -> saveAndGetBarcode(user));

--- a/src/main/java/com/example/membership/service/service/BarcodeCreateService.java
+++ b/src/main/java/com/example/membership/service/service/BarcodeCreateService.java
@@ -1,0 +1,35 @@
+package com.example.membership.service.service;
+
+import com.example.membership.service.infra.entity.*;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BarcodeCreateService {
+
+    private final UserRepository userRepository;
+    private final MembershipRepository membershipRepository;
+
+    public Membership createBarcode(Long userId) {
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+        return membershipRepository.findByUserId(user.getId())
+                .orElseGet(() -> saveAndGetBarcode(user));
+    }
+
+    private Membership saveAndGetBarcode(User user) {
+        String uuid = RandomStringUtils.randomNumeric(10);
+        return membershipRepository.save(
+                Membership.builder()
+                        .id(uuid)
+                        .user(user)
+                        .build()
+        );
+    }
+}
+
+

--- a/src/test/java/com/example/membership/service/service/BarcodeCreateServiceTest.java
+++ b/src/test/java/com/example/membership/service/service/BarcodeCreateServiceTest.java
@@ -1,0 +1,92 @@
+package com.example.membership.service.service;
+
+import com.example.membership.service.infra.entity.*;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@Transactional
+class BarcodeCreateServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private MembershipRepository membershipRepository;
+    @InjectMocks
+    private BarcodeCreateService barcodeCreateService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    private final Long userId = 123456789L;
+
+    @Test
+    void 바코드_발급_성공() {
+        // userRepository.findById() 메소드가 Optional.empty()를 반환하도록 설정
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // barcodeCreate() 메소드를 호출하면 RuntimeException이 발생하는지 검증
+        assertThrows(RuntimeException.class, () -> barcodeCreateService.createBarcode(userId));
+
+        // userRepository.findById() 메소드가 1번 호출되었는지 검증
+        verify(userRepository, times(1)).findById(userId);
+
+        // membershipRepository.save() 메소드가 호출되지 않았는지 검증
+        verify(membershipRepository, never()).save(any(Membership.class));
+
+
+    }
+
+    @Test
+    void membership_Id_10자리_숫자_확인() {
+        // 가상의 유저 객체 생성
+        User user = new User(userId);
+
+        // userRepository.findById() 메소드가 가상의 유저 객체를 반환하도록 설정
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        // barcodeCreate() 메소드 호출
+        barcodeCreateService.createBarcode(userId);
+
+        // membershipRepository.save() 메소드에 전달된 Membership 객체 캡처
+        ArgumentCaptor<Membership> captor = ArgumentCaptor.forClass(Membership.class);
+        verify(membershipRepository).save(captor.capture());
+
+        // 저장된 Membership 객체 가져오기
+        Membership savedMembership = captor.getValue();
+
+        assertTrue(savedMembership.getId().matches("\\d{10}"));
+    }
+
+    @Test
+    void user_id_없는_경우() {
+        // userRepository.findById() 메소드가 가상의 유저 객체를 반환하도록 설정
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // UserNotFoundException 이 동작하는지 확인
+        assertThrows(UserNotFoundException.class, () -> barcodeCreateService.createBarcode(userId));
+    }
+
+    @Test
+    void user_id_9자리_아닐때() {
+        Long userId2 = 01234567L;
+        User user = new User(userId2);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        assertThrows(UserIdLengthException.class, () -> barcodeCreateService.createBarcode(userId));
+    }
+}

--- a/src/test/java/com/example/membership/service/service/BarcodeCreateServiceTest.java
+++ b/src/test/java/com/example/membership/service/service/BarcodeCreateServiceTest.java
@@ -87,6 +87,6 @@ class BarcodeCreateServiceTest {
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
-        assertThrows(UserIdLengthException.class, () -> barcodeCreateService.createBarcode(userId));
+        assertThrows(UserIdLengthException.class, () -> barcodeCreateService.createBarcode(userId2));
     }
 }


### PR DESCRIPTION
ISSUE

https://github.com/a01575dc-b401-4506-8753-7d523b558dfa/membership-service/issues/15

To do

- [x] 회원 ID(9자리 숫자) 당 멤버십 ID(= 바코드 ID)가 10자리의 숫자 문자열로 발급됩니다.
- [x] 이미 발급된 아이디의 발급 요청 시 기존 멤버십 바코드를 반환합니다.
- [x] 다음에 발급되는 멤버십 바코드는 예측할 수 없어야 합니다.

Considerations

` N/A `